### PR TITLE
Update windows with correct line number

### DIFF
--- a/addons/beautify_code_on_save/plugin.gd
+++ b/addons/beautify_code_on_save/plugin.gd
@@ -188,7 +188,7 @@ func _show_lint_errors(output: String, path: String) -> void:
 		if error_parts.size() >= 2:
 			error_count += 1
 			var location = error_parts[0].get_file()
-			var line_number = error_parts[0].split(":")[1]
+			var line_number = error_parts[0].split(":")[2] if OS.get_name() == "Windows" else error_parts[0].split(":")[1]
 			var error_msg = error_parts[1]
 
 			print("%d) Line %s: %s" % [error_count, line_number, error_msg])


### PR DESCRIPTION
Update windows with correct line number.

Windows is having the disk letter + colon (ex: `E:`) as start of path, unlike *nix.
```
["E:/Game/scenes/player/player.gd:9", "Definition out of order in global scope (class-definitions-order)\r"]
```

This has caused the output log being incorrect due to using colon as a separator:
```
1) Line /Game/scenes/player/player.gd: Definition out of order in global scope (class-definitions-order)
```

With this fix the output is correct again on windows:
```
File: res://scenes/player/player.gd
1) Line 9: Definition out of order in global scope (class-definitions-order)
```

Thanks.